### PR TITLE
Correctly quote filename in Content-Disposition header

### DIFF
--- a/dhfb/app.py
+++ b/dhfb/app.py
@@ -163,8 +163,9 @@ def _get(path):
             yield chunk
 
     _, filename = os.path.split(path)
-    return Response(generate_file(s3_response), mimetype=s3_response['ContentType'],
-                    headers={'Content-Disposition': 'attachment;filename=' + filename})
+    response = Response(generate_file(s3_response), mimetype=s3_response['ContentType'])
+    response.headers.add('Content-Disposition', 'attachment', filename=filename)
+    return response
 
 
 @app.route('/storage/<path:path>')


### PR DESCRIPTION
It would be better to use flask.helpers.send_file(), but that would be a larger change.